### PR TITLE
Mandatory Nodes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,3 +30,14 @@ dependencies {
 
 	testCompile group: 'junit', name: 'junit', version: '4.+'
 }
+
+test{
+    testLogging {
+        events "passed", "skipped", "failed", "standardOut", "standardError"
+        showStandardStreams = true
+    }
+
+    beforeTest {
+        descriptor -> logger.lifecycle("Running test: " + descriptor)
+    }
+}

--- a/src/main/java/org/iti/structureGraph/IStructureGraph.java
+++ b/src/main/java/org/iti/structureGraph/IStructureGraph.java
@@ -38,6 +38,8 @@ public interface IStructureGraph {
 
 	IStructureElement getTargetElement(DefaultEdge edge);
 
+	IStructureElement getParent(IStructureElement structureElement);
+
 	String getIdentifier(IStructureElement structureElement);
 
 	String getPath(IStructureElement structureElement);

--- a/src/main/java/org/iti/structureGraph/StructureGraph.java
+++ b/src/main/java/org/iti/structureGraph/StructureGraph.java
@@ -36,13 +36,13 @@ import org.jgrapht.graph.DefaultEdge;
 public class StructureGraph implements IStructureGraph {
 
 	private DirectedGraph<IStructureElement, DefaultEdge> graph;
-	
+
 	private Map<String, IStructureElement> elementsByIdentifer = new HashMap<>();
 	private Map<String, DefaultEdge> pathesByIdentifer = new HashMap<>();
-	
+
 	public StructureGraph(DirectedGraph<IStructureElement, DefaultEdge> graph) {
 		this.graph = graph;
-		
+
 		loadElementsByIdentifier();
 		loadEdgesByIdentifier();
 	}
@@ -78,7 +78,7 @@ public class StructureGraph implements IStructureGraph {
 	}
 
 	private List<IStructureElement> getElementPathElements(IStructureElement element, boolean toRootElement) {
-		IStructureElement currentElement = element; 
+		IStructureElement currentElement = element;
 		LinkedList<IStructureElement> elements = new LinkedList<>();
 		int elementCount = (toRootElement) ? -1 : 2;
 
@@ -93,7 +93,8 @@ public class StructureGraph implements IStructureGraph {
 		return elements;
 	}
 
-	private IStructureElement getParent(IStructureElement element) {
+	@Override
+	public IStructureElement getParent(IStructureElement element) {
 		List<DefaultEdge> incomingEdges = getIncomingEdges(element);
 
 		if (!incomingEdges.isEmpty()) {
@@ -105,7 +106,7 @@ public class StructureGraph implements IStructureGraph {
 				}
 			}
 		}
-		
+
 		return null;
 	}
 

--- a/src/main/java/org/iti/structureGraph/comparison/SimpleStructureGraphComparer.java
+++ b/src/main/java/org/iti/structureGraph/comparison/SimpleStructureGraphComparer.java
@@ -34,6 +34,7 @@ import org.jgrapht.graph.DefaultEdge;
 
 public class SimpleStructureGraphComparer implements IStructureGraphComparer {
 
+	@Override
 	public StructureGraphComparisonResult compare(IStructureGraph oldGraph,
 			IStructureGraph newGraph) {
 		StructureGraphComparisonResult result = new StructureGraphComparisonResult(oldGraph, newGraph);
@@ -60,7 +61,7 @@ public class SimpleStructureGraphComparer implements IStructureGraphComparer {
 		oldNodes.removeAll(newNodes);
 
 		return oldNodes;
-	}	
+	}
 
 	private List<String> getMissingPathes(IStructureGraph oldGraph,
 			IStructureGraph newGraph) {

--- a/src/main/java/org/iti/structureGraph/comparison/SimpleStructureGraphComparer.java
+++ b/src/main/java/org/iti/structureGraph/comparison/SimpleStructureGraphComparer.java
@@ -47,6 +47,8 @@ public class SimpleStructureGraphComparer implements IStructureGraphComparer {
 		addPathesWithModificationToResult(oldGraph, removedPathes, Type.PathDeleted, result);
 		addPathesWithModificationToResult(newGraph, addedPathes, Type.PathAdded, result);
 
+		addMissingMandatoryNodesToResult(result);
+
 		return result;
 	}
 
@@ -109,5 +111,25 @@ public class SimpleStructureGraphComparer implements IStructureGraphComparer {
 
 			result.addModification(path, modification);
 		}
+	}
+
+	private void addMissingMandatoryNodesToResult(StructureGraphComparisonResult result) {
+		for (IStructureElement element : result.getElementsByModification(Type.NodeAdded)) {
+			if (element.isMandatory() && parentExists(result, element)) {
+				String fullIdentifier = result.getNewGraph().getIdentifier(element);
+				String path = result.getNewGraph().getPath(element);
+				StructureElementModification modification = new StructureElementModification(path, element.getIdentifier(), Type.NodeDeleted);
+
+				result.removeModification(fullIdentifier);
+				result.addModification(fullIdentifier, modification);
+			}
+		}
+	}
+
+	private boolean parentExists(StructureGraphComparisonResult result, IStructureElement element) {
+		DefaultEdge edge = result.getNewGraph().getEdge(result.getNewGraph().getPath(element, false));
+		IStructureElement parent = result.getNewGraph().getSourceElement(edge);
+
+		return parent != null && result.getOldGraph().containsElementWithPath(result.getNewGraph().getIdentifier(parent));
 	}
 }

--- a/src/main/java/org/iti/structureGraph/comparison/SimpleStructureGraphComparer.java
+++ b/src/main/java/org/iti/structureGraph/comparison/SimpleStructureGraphComparer.java
@@ -48,8 +48,6 @@ public class SimpleStructureGraphComparer implements IStructureGraphComparer {
 		addPathesWithModificationToResult(oldGraph, removedPathes, Type.PathDeleted, result);
 		addPathesWithModificationToResult(newGraph, addedPathes, Type.PathAdded, result);
 
-		addMissingMandatoryNodesToResult(result);
-
 		return result;
 	}
 
@@ -112,25 +110,5 @@ public class SimpleStructureGraphComparer implements IStructureGraphComparer {
 
 			result.addModification(path, modification);
 		}
-	}
-
-	private void addMissingMandatoryNodesToResult(StructureGraphComparisonResult result) {
-		for (IStructureElement element : result.getElementsByModification(Type.NodeAdded)) {
-			if (element.isMandatory() && parentExists(result, element)) {
-				String fullIdentifier = result.getNewGraph().getIdentifier(element);
-				String path = result.getNewGraph().getPath(element);
-				StructureElementModification modification = new StructureElementModification(path, element.getIdentifier(), Type.NodeDeleted);
-
-				result.removeModification(fullIdentifier);
-				result.addModification(fullIdentifier, modification);
-			}
-		}
-	}
-
-	private boolean parentExists(StructureGraphComparisonResult result, IStructureElement element) {
-		DefaultEdge edge = result.getNewGraph().getEdge(result.getNewGraph().getPath(element, false));
-		IStructureElement parent = result.getNewGraph().getSourceElement(edge);
-
-		return parent != null && result.getOldGraph().containsElementWithPath(result.getNewGraph().getIdentifier(parent));
 	}
 }

--- a/src/main/java/org/iti/structureGraph/comparison/StatementStructureGraphComparer.java
+++ b/src/main/java/org/iti/structureGraph/comparison/StatementStructureGraphComparer.java
@@ -1,11 +1,9 @@
 package org.iti.structureGraph.comparison;
 
 import org.iti.structureGraph.IStructureGraph;
-import org.iti.structureGraph.comparison.result.StructureElementModification;
 import org.iti.structureGraph.comparison.result.StructureGraphComparisonResult;
 import org.iti.structureGraph.comparison.result.Type;
 import org.iti.structureGraph.nodes.IStructureElement;
-import org.jgrapht.graph.DefaultEdge;
 
 public class StatementStructureGraphComparer implements IStructureGraphComparer {
 
@@ -15,29 +13,27 @@ public class StatementStructureGraphComparer implements IStructureGraphComparer 
 		IStructureGraphComparer comparer = new SimpleStructureGraphComparer();
 		StructureGraphComparisonResult result = comparer.compare(statement, structure);
 
-		addMissingMandatoryNodesToResult(result);
+		removeNonMandatoryNodeAdditions(result);
 
 		return result;
 	}
 
-	private void addMissingMandatoryNodesToResult(StructureGraphComparisonResult result) {
+	private void removeNonMandatoryNodeAdditions(StructureGraphComparisonResult result) {
 		for (IStructureElement element : result.getElementsByModification(Type.NodeAdded)) {
-			if (element.isMandatory() && parentExists(result, element)) {
+			if (!(element.isMandatory() && parentExists(result, element))) {
 				String fullIdentifier = result.getNewGraph().getIdentifier(element);
-				String path = result.getNewGraph().getPath(element);
-				StructureElementModification modification = new StructureElementModification(path, element.getIdentifier(), Type.NodeDeleted);
 
 				result.removeModification(fullIdentifier);
-				result.addModification(fullIdentifier, modification);
 			}
 		}
 	}
 
 	private boolean parentExists(StructureGraphComparisonResult result, IStructureElement element) {
-		DefaultEdge edge = result.getNewGraph().getEdge(result.getNewGraph().getPath(element, false));
-		IStructureElement parent = result.getNewGraph().getSourceElement(edge);
+		IStructureElement parent = result.getNewGraph().getParent(element);
+		String fullIdentifierParent = result.getNewGraph().getIdentifier(parent);
+		IStructureElement parentInOldGraph = result.getOldGraph().getStructureElement(fullIdentifierParent);
 
-		return parent != null && result.getOldGraph().containsElementWithPath(result.getNewGraph().getIdentifier(parent));
+		return parentInOldGraph != null && result.getOldGraph().containsElementWithPath(result.getOldGraph().getIdentifier(parentInOldGraph));
 	}
 
 }

--- a/src/main/java/org/iti/structureGraph/comparison/StatementStructureGraphComparer.java
+++ b/src/main/java/org/iti/structureGraph/comparison/StatementStructureGraphComparer.java
@@ -1,0 +1,43 @@
+package org.iti.structureGraph.comparison;
+
+import org.iti.structureGraph.IStructureGraph;
+import org.iti.structureGraph.comparison.result.StructureElementModification;
+import org.iti.structureGraph.comparison.result.StructureGraphComparisonResult;
+import org.iti.structureGraph.comparison.result.Type;
+import org.iti.structureGraph.nodes.IStructureElement;
+import org.jgrapht.graph.DefaultEdge;
+
+public class StatementStructureGraphComparer implements IStructureGraphComparer {
+
+	@Override
+	public StructureGraphComparisonResult compare(IStructureGraph statement, IStructureGraph structure)
+			throws StructureGraphComparisonException {
+		IStructureGraphComparer comparer = new SimpleStructureGraphComparer();
+		StructureGraphComparisonResult result = comparer.compare(statement, structure);
+
+		addMissingMandatoryNodesToResult(result);
+
+		return result;
+	}
+
+	private void addMissingMandatoryNodesToResult(StructureGraphComparisonResult result) {
+		for (IStructureElement element : result.getElementsByModification(Type.NodeAdded)) {
+			if (element.isMandatory() && parentExists(result, element)) {
+				String fullIdentifier = result.getNewGraph().getIdentifier(element);
+				String path = result.getNewGraph().getPath(element);
+				StructureElementModification modification = new StructureElementModification(path, element.getIdentifier(), Type.NodeDeleted);
+
+				result.removeModification(fullIdentifier);
+				result.addModification(fullIdentifier, modification);
+			}
+		}
+	}
+
+	private boolean parentExists(StructureGraphComparisonResult result, IStructureElement element) {
+		DefaultEdge edge = result.getNewGraph().getEdge(result.getNewGraph().getPath(element, false));
+		IStructureElement parent = result.getNewGraph().getSourceElement(edge);
+
+		return parent != null && result.getOldGraph().containsElementWithPath(result.getNewGraph().getIdentifier(parent));
+	}
+
+}

--- a/src/main/java/org/iti/structureGraph/nodes/IMandatoryElement.java
+++ b/src/main/java/org/iti/structureGraph/nodes/IMandatoryElement.java
@@ -1,0 +1,6 @@
+package org.iti.structureGraph.nodes;
+
+public interface IMandatoryElement {
+
+	boolean isMandatory();
+}

--- a/src/main/java/org/iti/structureGraph/nodes/IStructureElement.java
+++ b/src/main/java/org/iti/structureGraph/nodes/IStructureElement.java
@@ -21,7 +21,7 @@
 
 package org.iti.structureGraph.nodes;
 
-public interface IStructureElement {
+public interface IStructureElement extends IMandatoryElement {
 
 	public String getIdentifier();
 }

--- a/src/test/java/org/iti/structureGraph/comparison/SimpleStructureGraphNodeComparerTest.java
+++ b/src/test/java/org/iti/structureGraph/comparison/SimpleStructureGraphNodeComparerTest.java
@@ -44,13 +44,13 @@ public class SimpleStructureGraphNodeComparerTest {
 	private static IStructureGraphComparer comparer = new SimpleStructureGraphComparer();
 
 	private static StructureGraph structureGraphOriginal;
-	
+
 	private DirectedGraph<IStructureElement, DefaultEdge> currentGraph;
 
 	private Map<String, Type> expectedModifications = new HashMap<>();
 
 	private StructureGraphComparisonResult result;
-	
+
 	@BeforeClass
 	public static void init() throws Exception {
 		structureGraphOriginal = StructureGraphComparerTestHelper.getOriginal();

--- a/src/test/java/org/iti/structureGraph/comparison/SimpleStructureGraphNodeComparerTest.java
+++ b/src/test/java/org/iti/structureGraph/comparison/SimpleStructureGraphNodeComparerTest.java
@@ -136,10 +136,33 @@ public class SimpleStructureGraphNodeComparerTest {
 		StructureGraphComparerTestHelper.assertModificationExpectations(expectedModifications, result);
 	}
 
+	@Test
+	public void detectsMissingMandatoryNode() throws StructureGraphComparisonException {
+		StructureGraphComparerTestHelper.givenRemovedNodes(currentGraph);
+		StructureGraphComparerTestHelper.givenExpectedNodeRemovals(StructureGraphComparerTestHelper.cn3, structureGraphOriginal, expectedModifications);
+		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn2, structureGraphOriginal, expectedModifications);
+		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn5, structureGraphOriginal, expectedModifications);
+		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn6, structureGraphOriginal, expectedModifications);
+
+		whenComparisonResultIsCreatedAgainstCurrentGraph();
+
+		assertEquals(expectedModifications.size(), result.getNodeModifications().size());
+
+		StructureGraphComparerTestHelper.assertModificationExpectations(expectedModifications, result);
+	}
+
 	private void whenComparisonResultIsCreated()
 			throws StructureGraphComparisonException {
 		StructureGraph structureGraphCurrent = new StructureGraph(currentGraph);
 
 		result = comparer.compare(structureGraphOriginal, structureGraphCurrent);
+	}
+
+	private void whenComparisonResultIsCreatedAgainstCurrentGraph() throws StructureGraphComparisonException {
+
+		StructureGraph structureGraphCurrent = new StructureGraph(currentGraph);
+
+		result = comparer.compare(structureGraphCurrent, structureGraphOriginal);
+
 	}
 }

--- a/src/test/java/org/iti/structureGraph/comparison/SimpleStructureGraphNodeComparerTest.java
+++ b/src/test/java/org/iti/structureGraph/comparison/SimpleStructureGraphNodeComparerTest.java
@@ -136,33 +136,10 @@ public class SimpleStructureGraphNodeComparerTest {
 		StructureGraphComparerTestHelper.assertModificationExpectations(expectedModifications, result);
 	}
 
-	@Test
-	public void detectsMissingMandatoryNode() throws StructureGraphComparisonException {
-		StructureGraphComparerTestHelper.givenRemovedNodes(currentGraph);
-		StructureGraphComparerTestHelper.givenExpectedNodeRemovals(StructureGraphComparerTestHelper.cn3, structureGraphOriginal, expectedModifications);
-		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn2, structureGraphOriginal, expectedModifications);
-		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn5, structureGraphOriginal, expectedModifications);
-		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn6, structureGraphOriginal, expectedModifications);
-
-		whenComparisonResultIsCreatedAgainstCurrentGraph();
-
-		assertEquals(expectedModifications.size(), result.getNodeModifications().size());
-
-		StructureGraphComparerTestHelper.assertModificationExpectations(expectedModifications, result);
-	}
-
 	private void whenComparisonResultIsCreated()
 			throws StructureGraphComparisonException {
 		StructureGraph structureGraphCurrent = new StructureGraph(currentGraph);
 
 		result = comparer.compare(structureGraphOriginal, structureGraphCurrent);
-	}
-
-	private void whenComparisonResultIsCreatedAgainstCurrentGraph() throws StructureGraphComparisonException {
-
-		StructureGraph structureGraphCurrent = new StructureGraph(currentGraph);
-
-		result = comparer.compare(structureGraphCurrent, structureGraphOriginal);
-
 	}
 }

--- a/src/test/java/org/iti/structureGraph/comparison/SimpleStructureGraphNodeComparerTest.java
+++ b/src/test/java/org/iti/structureGraph/comparison/SimpleStructureGraphNodeComparerTest.java
@@ -66,6 +66,13 @@ public class SimpleStructureGraphNodeComparerTest {
 	}
 
 	@Test
+	public void detectsIsomorphicGraphs() throws StructureGraphComparisonException {
+		whenComparisonResultIsCreated();
+
+		assertEquals(0, result.getNodeModifications().size());
+	}
+
+	@Test
 	public void detectsRemovedNodes() throws StructureGraphComparisonException {
 		StructureGraphComparerTestHelper.givenRemovedNodes(currentGraph);
 		StructureGraphComparerTestHelper.givenExpectedNodeRemovals(structureGraphOriginal, expectedModifications);

--- a/src/test/java/org/iti/structureGraph/comparison/StatementGraphComparerTestHelper.java
+++ b/src/test/java/org/iti/structureGraph/comparison/StatementGraphComparerTestHelper.java
@@ -1,0 +1,71 @@
+package org.iti.structureGraph.comparison;
+
+import org.iti.structureGraph.StructureGraph;
+import org.iti.structureGraph.helper.Edge2;
+import org.iti.structureGraph.helper.Edge3;
+import org.iti.structureGraph.helper.Element;
+import org.iti.structureGraph.nodes.IStructureElement;
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.SimpleDirectedGraph;
+
+public class StatementGraphComparerTestHelper {
+
+	static Element cn1 = new Element("cn1");
+	static Element cn2 = new Element("cn2");
+	static Element cn3 = new Element("cn3", true);
+	static Element cn4 = new Element("cn4", true);
+	static Element cn41 = new Element("cn41", true);
+	static Element cn5 = new Element("cn5");
+	static Element cn6 = new Element("cn6");
+	static Element cn7 = new Element("cn7", true);
+	static Element cn8 = new Element("cn8", true);
+
+	static StructureGraph getOriginal() {
+		DirectedGraph<IStructureElement, DefaultEdge> originalGraph = new SimpleDirectedGraph<IStructureElement, DefaultEdge>(DefaultEdge.class);
+
+		originalGraph.addVertex(cn1);
+		originalGraph.addVertex(cn2);
+		originalGraph.addVertex(cn3);
+		originalGraph.addVertex(cn4);
+		originalGraph.addVertex(cn5);
+		originalGraph.addVertex(cn6);
+		originalGraph.addVertex(cn7);
+		originalGraph.addVertex(cn8);
+
+		originalGraph.addEdge(cn1, cn2, new Edge2());
+		originalGraph.addEdge(cn2, cn3, new Edge3());
+		originalGraph.addEdge(cn2, cn4, new Edge3());
+
+		originalGraph.addEdge(cn5, cn6, new Edge2());
+		originalGraph.addEdge(cn6, cn7, new Edge3());
+		originalGraph.addEdge(cn6, cn8, new Edge3());
+
+		return new StructureGraph(originalGraph);
+	}
+
+	static SimpleDirectedGraph<IStructureElement, DefaultEdge> getCurrentGraph() {
+		SimpleDirectedGraph<IStructureElement, DefaultEdge> currentGraph = new SimpleDirectedGraph<IStructureElement, DefaultEdge>(DefaultEdge.class);
+
+		currentGraph.addVertex(cn1);
+		currentGraph.addVertex(cn2);
+		currentGraph.addVertex(cn3);
+		currentGraph.addVertex(cn4);
+
+		currentGraph.addEdge(cn1, cn2, new Edge2());
+		currentGraph.addEdge(cn2, cn3, new Edge3());
+		currentGraph.addEdge(cn2, cn4, new Edge3());
+
+		return currentGraph;
+	}
+
+	public static void givenMissingMandatoryNode(DirectedGraph<IStructureElement, DefaultEdge> graph) {
+		graph.removeVertex(cn4);
+	}
+
+	public static void givenSuperfluousMandatoryNode(DirectedGraph<IStructureElement, DefaultEdge> graph) {
+		graph.addVertex(cn41);
+
+		graph.addEdge(cn2, cn41, new Edge3());
+	}
+}

--- a/src/test/java/org/iti/structureGraph/comparison/StatementStructureGraphNodeComparerTest.java
+++ b/src/test/java/org/iti/structureGraph/comparison/StatementStructureGraphNodeComparerTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 1999 Hagen Schink <hagen.schink@gmail.com>
+ *
+ *  This file is part of sql-schema-comparer.
+ *
+ *  sql-schema-comparer is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  sql-schema-comparer is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with sql-schema-comparer.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package org.iti.structureGraph.comparison;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.iti.structureGraph.StructureGraph;
+import org.iti.structureGraph.comparison.result.StructureGraphComparisonResult;
+import org.iti.structureGraph.comparison.result.Type;
+import org.iti.structureGraph.nodes.IStructureElement;
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class StatementStructureGraphNodeComparerTest {
+
+	private static IStructureGraphComparer comparer = new StatementStructureGraphComparer();
+
+	private static StructureGraph structureGraph;
+
+	private DirectedGraph<IStructureElement, DefaultEdge> statementGraph;
+
+	private Map<String, Type> expectedModifications = new HashMap<>();
+
+	private StructureGraphComparisonResult result;
+
+	@BeforeClass
+	public static void init() throws Exception {
+		structureGraph = StructureGraphComparerTestHelper.getOriginal();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		statementGraph = StructureGraphComparerTestHelper.getCurrentGraph();
+
+		expectedModifications.clear();
+
+		result = null;
+	}
+
+	@Test
+	public void detectsMissingMandatoryNode() throws StructureGraphComparisonException {
+		StructureGraphComparerTestHelper.givenRemovedNodes(statementGraph);
+		StructureGraphComparerTestHelper.givenExpectedNodeRemovals(StructureGraphComparerTestHelper.cn3, structureGraph, expectedModifications);
+		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn2, structureGraph, expectedModifications);
+		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn5, structureGraph, expectedModifications);
+		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn6, structureGraph, expectedModifications);
+
+		whenComparisonResultIsCreatedAgainstCurrentGraph();
+
+		assertEquals(expectedModifications.size(), result.getNodeModifications().size());
+
+		StructureGraphComparerTestHelper.assertModificationExpectations(expectedModifications, result);
+	}
+
+	private void whenComparisonResultIsCreatedAgainstCurrentGraph() throws StructureGraphComparisonException {
+
+		StructureGraph structureGraphCurrent = new StructureGraph(statementGraph);
+
+		result = comparer.compare(structureGraphCurrent, structureGraph);
+
+	}
+}

--- a/src/test/java/org/iti/structureGraph/comparison/StatementStructureGraphNodeComparerTest.java
+++ b/src/test/java/org/iti/structureGraph/comparison/StatementStructureGraphNodeComparerTest.java
@@ -50,12 +50,12 @@ public class StatementStructureGraphNodeComparerTest {
 
 	@BeforeClass
 	public static void init() throws Exception {
-		structureGraph = StructureGraphComparerTestHelper.getOriginal();
+		structureGraph = StatementGraphComparerTestHelper.getOriginal();
 	}
 
 	@Before
 	public void setUp() throws Exception {
-		statementGraph = StructureGraphComparerTestHelper.getCurrentGraph();
+		statementGraph = StatementGraphComparerTestHelper.getCurrentGraph();
 
 		expectedModifications.clear();
 
@@ -63,21 +63,39 @@ public class StatementStructureGraphNodeComparerTest {
 	}
 
 	@Test
-	public void detectsMissingMandatoryNode() throws StructureGraphComparisonException {
-		StructureGraphComparerTestHelper.givenRemovedNodes(statementGraph);
-		StructureGraphComparerTestHelper.givenExpectedNodeRemovals(StructureGraphComparerTestHelper.cn3, structureGraph, expectedModifications);
-		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn2, structureGraph, expectedModifications);
-		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn5, structureGraph, expectedModifications);
-		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StructureGraphComparerTestHelper.cn6, structureGraph, expectedModifications);
-
-		whenComparisonResultIsCreatedAgainstCurrentGraph();
+	public void detectsSubgraphIsomorphism() throws StructureGraphComparisonException {
+		whenComparisonResultIsCreated();
 
 		assertEquals(expectedModifications.size(), result.getNodeModifications().size());
 
 		StructureGraphComparerTestHelper.assertModificationExpectations(expectedModifications, result);
 	}
 
-	private void whenComparisonResultIsCreatedAgainstCurrentGraph() throws StructureGraphComparisonException {
+	@Test
+	public void detectsMissingMandatoryNode() throws StructureGraphComparisonException {
+		StatementGraphComparerTestHelper.givenMissingMandatoryNode(statementGraph);
+		StructureGraphComparerTestHelper.givenExpectedNodeAddition(StatementGraphComparerTestHelper.cn4, structureGraph, expectedModifications);
+
+		whenComparisonResultIsCreated();
+
+		assertEquals(expectedModifications.size(), result.getNodeModifications().size());
+
+		StructureGraphComparerTestHelper.assertModificationExpectations(expectedModifications, result);
+	}
+
+	@Test
+	public void handlesSuperfluousNodes() throws StructureGraphComparisonException {
+		StatementGraphComparerTestHelper.givenSuperfluousMandatoryNode(statementGraph);
+		StructureGraphComparerTestHelper.givenExpectedNodeRemovals(StatementGraphComparerTestHelper.cn41, new StructureGraph(statementGraph), expectedModifications);
+
+		whenComparisonResultIsCreated();
+
+		assertEquals(expectedModifications.size(), result.getNodeModifications().size());
+
+		StructureGraphComparerTestHelper.assertModificationExpectations(expectedModifications, result);
+	}
+
+	private void whenComparisonResultIsCreated() throws StructureGraphComparisonException {
 
 		StructureGraph structureGraphCurrent = new StructureGraph(statementGraph);
 

--- a/src/test/java/org/iti/structureGraph/comparison/StructureGraphComparerTestHelper.java
+++ b/src/test/java/org/iti/structureGraph/comparison/StructureGraphComparerTestHelper.java
@@ -31,9 +31,9 @@ public class StructureGraphComparerTestHelper {
 	static Element re = new Element("re");
 	static Element cn1 = new Element("cn1");
 	static Element cn2 = new Element("cn2");
-	static Element cn3 = new Element("cn3");
+	static Element cn3 = new Element("cn3", true);
 	static Element cn4 = new Element("cn4");
-	static Element cn5 = new Element("cn5");
+	static Element cn5 = new Element("cn5", true);
 	static Element cn6 = new Element("cn6");
 	static Element cn7 = new Element("cn7");
 	static Element cn8 = new Element("cn8");

--- a/src/test/java/org/iti/structureGraph/helper/Element.java
+++ b/src/test/java/org/iti/structureGraph/helper/Element.java
@@ -26,13 +26,25 @@ import org.iti.structureGraph.nodes.IStructureElement;
 public class Element implements IStructureElement {
 
 	private String identifier = "";
-	
+	private boolean mandatory = false;
+
 	public Element(String identifier) {
 		this.identifier = identifier;
+	}
+
+	public Element(String identifier, boolean mandatory) {
+		this(identifier);
+
+		this.mandatory = mandatory;
 	}
 
 	@Override
 	public String getIdentifier() {
 		return identifier;
+	}
+
+	@Override
+	public boolean isMandatory() {
+		return mandatory;
 	}
 }


### PR DESCRIPTION
This branch creates the ability to detect _mandatory nodes_. Mandatory nodes are nodes which should exist in any case (for instance parameters of a function or references to columns with a `NOT NULL` constraint).

Mandatory nodes are added nodes for which the `MANDATORY` flag is set. 
